### PR TITLE
#13 화면 회전 시 Layout이 유지되도록 수정

### DIFF
--- a/image-search-task/image-search-task.xcodeproj/project.pbxproj
+++ b/image-search-task/image-search-task.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AB0FA3B129ADCE8B0090D643 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB0FA3B029ADCE8B0090D643 /* Assets.xcassets */; };
 		AB0FA3B429ADCE8B0090D643 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB0FA3B229ADCE8B0090D643 /* LaunchScreen.storyboard */; };
 		AB115CED29B3BA1300D297C6 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB115CEC29B3BA1300D297C6 /* String+Extension.swift */; };
+		AB115CEF29B3DB7700D297C6 /* DefaultListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB115CEE29B3DB7700D297C6 /* DefaultListView.swift */; };
 		AB783F8729ADF1BE00A08022 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB783F8629ADF1BE00A08022 /* UIView+Extension.swift */; };
 		AB783F8929AE02D100A08022 /* SearchBarCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB783F8829AE02D100A08022 /* SearchBarCase.swift */; };
 		AB783F8E29AE2D0C00A08022 /* ImageItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB783F8D29AE2D0C00A08022 /* ImageItemCell.swift */; };
@@ -52,6 +53,7 @@
 		AB0FA3B329ADCE8B0090D643 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AB0FA3B529ADCE8B0090D643 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB115CEC29B3BA1300D297C6 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		AB115CEE29B3DB7700D297C6 /* DefaultListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultListView.swift; sourceTree = "<group>"; };
 		AB783F8629ADF1BE00A08022 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		AB783F8829AE02D100A08022 /* SearchBarCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarCase.swift; sourceTree = "<group>"; };
 		AB783F8D29AE2D0C00A08022 /* ImageItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageItemCell.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				AB783F9A29AFACAA00A08022 /* ResponseModel.swift */,
 				AB783FA229B07A5A00A08022 /* Environment.swift */,
 				ABA1E71329B1DB4F003F1237 /* CoreDataStore.swift */,
+				AB115CEE29B3DB7700D297C6 /* DefaultListView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				AB783FA329B07A5A00A08022 /* Environment.swift in Sources */,
 				ABA1E72029B2539A003F1237 /* ImageEntity+CoreDataProperties.swift in Sources */,
 				AB0FA3AC29ADCE890090D643 /* ImageSearchViewController.swift in Sources */,
+				AB115CEF29B3DB7700D297C6 /* DefaultListView.swift in Sources */,
 				ABA1E72C29B270FE003F1237 /* NetworkError.swift in Sources */,
 				ABA1E72429B255CA003F1237 /* BookmarkListView.swift in Sources */,
 				AB783F9329AF260D00A08022 /* NetworkRequestable.swift in Sources */,

--- a/image-search-task/image-search-task/Common/DefaultListView.swift
+++ b/image-search-task/image-search-task/Common/DefaultListView.swift
@@ -1,0 +1,79 @@
+//
+//  DefaultListView.swift
+//  image-search-task
+//
+//  Created by inae Lee on 2023/03/05.
+//
+
+import RxSwift
+import UIKit
+
+class DefaultListView: UIView {
+    weak var viewModel: ImageSearchViewModel?
+    private(set) var bookmarkButtonTapAction = PublishSubject<ImageItem>()
+    var disposeBag = DisposeBag()
+
+    private(set) lazy var collectionView: UICollectionView = {
+        let view = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: self.collectionViewLayout
+        )
+        view.backgroundColor = .white
+        view.register(
+            ImageItemCell.self,
+            forCellWithReuseIdentifier: ImageItemCell.identifier
+        )
+        view.contentInsetAdjustmentBehavior = .never
+        return view
+    }()
+
+    private(set) lazy var collectionViewLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.sectionHeadersPinToVisibleBounds = true
+        return layout
+    }()
+
+    init(_ viewModel: ImageSearchViewModel) {
+        super.init(frame: .zero)
+        self.viewModel = viewModel
+
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func viewWillTransition() {
+        resizeCells()
+    }
+
+    func setupUI() {
+        addSubview(collectionView)
+        collectionView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+extension DefaultListView {
+    func calcRatioHeight(width: CGFloat, height: CGFloat) -> CGFloat {
+        guard !width.isZero else { return 100 }
+
+        let ratio = UIScreen.main.bounds.width / width
+        return height * ratio
+    }
+
+    func resizeCells() {
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            guard let _ = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
+                layout.itemSize = CGSize.zero
+                return
+            }
+
+            layout.invalidateLayout()
+        }
+    }
+}

--- a/image-search-task/image-search-task/Common/DefaultListView.swift
+++ b/image-search-task/image-search-task/Common/DefaultListView.swift
@@ -9,7 +9,7 @@ import RxSwift
 import UIKit
 
 class DefaultListView: UIView {
-    weak var viewModel: ImageSearchViewModel?
+    private(set) weak var viewModel: ImageSearchViewModel?
     private(set) var bookmarkButtonTapAction = PublishSubject<ImageItem>()
     var disposeBag = DisposeBag()
 

--- a/image-search-task/image-search-task/Data/BookmarkRepository.swift
+++ b/image-search-task/image-search-task/Data/BookmarkRepository.swift
@@ -61,8 +61,6 @@ struct BookmarkRepository: BookmarkRepositoryProtocol {
             let fetchRequest: NSFetchRequest<ImageEntity> = ImageEntity.fetchRequest()
             do {
                 let entities = try coreDataStore.viewContext.fetch(fetchRequest)
-                print(entities.map(\.url))
-                print("=============")
                 single(.success(entities))
             } catch {
                 print("[Core Data] load all list error \(error)")

--- a/image-search-task/image-search-task/ImageSearch/UI/BookmarkListView.swift
+++ b/image-search-task/image-search-task/ImageSearch/UI/BookmarkListView.swift
@@ -8,60 +8,26 @@
 import RxSwift
 import UIKit
 
-final class BookmarkListView: UIView {
-    private weak var viewModel: ImageSearchViewModel?
-    private let bookmarkButtonTapAction = PublishSubject<ImageItem>()
+final class BookmarkListView: DefaultListView {
     private let editButtonTapAction = PublishSubject<Bool>()
     private let finishButtonTapAction = PublishSubject<Void>()
-    private var disposeBag = DisposeBag()
 
-    private lazy var collectionView: UICollectionView = {
-        let view = UICollectionView(
-            frame: .zero,
-            collectionViewLayout: collectionViewLayout
-        )
-        view.backgroundColor = .white
-        view.register(
-            ImageItemCell.self,
-            forCellWithReuseIdentifier: ImageItemCell.identifier
-        )
-        view.register(
+    override init(_ viewModel: ImageSearchViewModel) {
+        super.init(viewModel)
+
+        configureCollectionView()
+        bind()
+    }
+
+    private func configureCollectionView() {
+        collectionView.register(
             BookmarkHeaderView.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: BookmarkHeaderView.identifier
         )
-        view.dataSource = self
-        view.delegate = self
-        view.contentInsetAdjustmentBehavior = .never
-        view.allowsMultipleSelection = true
-        return view
-    }()
-
-    private lazy var collectionViewLayout: UICollectionViewFlowLayout = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .vertical
-        layout.sectionHeadersPinToVisibleBounds = true
-        return layout
-    }()
-
-    init(_ viewModel: ImageSearchViewModel) {
-        super.init(frame: .zero)
-        self.viewModel = viewModel
-
-        setupUI()
-        bind()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setupUI() {
-        addSubview(collectionView)
-        collectionView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+        collectionView.allowsMultipleSelection = true
+        collectionView.delegate = self
+        collectionView.dataSource = self
     }
 
     private func bind() {
@@ -158,13 +124,6 @@ extension BookmarkListView: UICollectionViewDelegateFlowLayout {
         let height = calcRatioHeight(width: item.width, height: item.height)
 
         return .init(width: UIScreen.main.bounds.width, height: height + 44)
-    }
-
-    private func calcRatioHeight(width: CGFloat, height: CGFloat) -> CGFloat {
-        guard !width.isZero else { return 100 }
-
-        let ratio = UIScreen.main.bounds.width / width
-        return height * ratio
     }
 
     func collectionView(

--- a/image-search-task/image-search-task/ImageSearch/UI/ImageListView.swift
+++ b/image-search-task/image-search-task/ImageSearch/UI/ImageListView.swift
@@ -54,6 +54,10 @@ final class ImageListView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func viewWillTransition() {
+        resizeCells()
+    }
+
     private func setupUI() {
         addSubview(collectionView)
         collectionView.snp.makeConstraints { make in
@@ -151,5 +155,16 @@ extension ImageListView: UICollectionViewDelegateFlowLayout {
 
         let ratio = UIScreen.main.bounds.width / width
         return height * ratio
+    }
+
+    private func resizeCells() {
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            guard let _ = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
+                layout.itemSize = CGSize.zero
+                return
+            }
+
+            layout.invalidateLayout()
+        }
     }
 }

--- a/image-search-task/image-search-task/ImageSearch/UI/ImageListView.swift
+++ b/image-search-task/image-search-task/ImageSearch/UI/ImageListView.swift
@@ -8,61 +8,23 @@
 import RxSwift
 import UIKit
 
-final class ImageListView: UIView {
-    private weak var viewModel: ImageSearchViewModel?
-    private let bookmarkButtonTapAction = PublishSubject<ImageItem>()
-    private var disposeBag = DisposeBag()
+final class ImageListView: DefaultListView {
+    override init(_ viewModel: ImageSearchViewModel) {
+        super.init(viewModel)
 
-    private lazy var collectionView: UICollectionView = {
-        let view = UICollectionView(
-            frame: .zero,
-            collectionViewLayout: collectionViewLayout
-        )
-        view.backgroundColor = .white
-        view.register(
-            ImageItemCell.self,
-            forCellWithReuseIdentifier: ImageItemCell.identifier
-        )
-        view.register(
-            EmptyCell.self,
-            forCellWithReuseIdentifier: EmptyCell.identifier
-        )
-        view.allowsMultipleSelection = false
-        view.allowsSelection = false
-        view.contentInsetAdjustmentBehavior = .never
-        view.dataSource = self
-        view.delegate = self
-        return view
-    }()
-
-    private lazy var collectionViewLayout: UICollectionViewFlowLayout = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .vertical
-        return layout
-    }()
-
-    init(_ viewModel: ImageSearchViewModel) {
-        super.init(frame: .zero)
-        self.viewModel = viewModel
-
-        setupUI()
+        configureCollectionView()
         bind()
     }
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func viewWillTransition() {
-        resizeCells()
-    }
-
-    private func setupUI() {
-        addSubview(collectionView)
-        collectionView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+    private func configureCollectionView() {
+        collectionView.register(
+            EmptyCell.self,
+            forCellWithReuseIdentifier: EmptyCell.identifier
+        )
+        collectionView.allowsMultipleSelection = false
+        collectionView.allowsSelection = false
+        collectionView.delegate = self
+        collectionView.dataSource = self
     }
 
     private func bind() {
@@ -150,21 +112,11 @@ extension ImageListView: UICollectionViewDelegateFlowLayout {
         }
     }
 
-    private func calcRatioHeight(width: CGFloat, height: CGFloat) -> CGFloat {
-        guard !width.isZero else { return 100 }
-
-        let ratio = UIScreen.main.bounds.width / width
-        return height * ratio
-    }
-
-    private func resizeCells() {
-        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            guard let _ = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else {
-                layout.itemSize = CGSize.zero
-                return
-            }
-
-            layout.invalidateLayout()
-        }
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForHeaderInSection section: Int
+    ) -> CGSize {
+        CGSize(width: UIScreen.main.bounds.width, height: 44)
     }
 }

--- a/image-search-task/image-search-task/ImageSearch/UI/ImageSearchViewController.swift
+++ b/image-search-task/image-search-task/ImageSearch/UI/ImageSearchViewController.swift
@@ -42,6 +42,11 @@ final class ImageSearchViewController: UIViewController {
         bind()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        imageListView.viewWillTransition()
+        super.viewWillTransition(to: size, with: coordinator)
+    }
+
     private func setupUI() {
         view.addSubviews([searchBar, imageListView, bookmarkListView])
 

--- a/image-search-task/image-search-task/ImageSearch/UI/ImageSearchViewController.swift
+++ b/image-search-task/image-search-task/ImageSearch/UI/ImageSearchViewController.swift
@@ -44,6 +44,7 @@ final class ImageSearchViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         imageListView.viewWillTransition()
+        bookmarkListView.viewWillTransition()
         super.viewWillTransition(to: size, with: coordinator)
     }
 


### PR DESCRIPTION
ViewController의 lifeCycle 메소드인 `willTransiton`함수가 호출될 때, subView에게 cell layout의 재계산을 요청합니다.
또, subView (이미지 아이템, 북마크 리스트 뷰)들의 공통 UI를 처리하는 `DefaultListView`를 선언해 상속받았습니다. 

closed #13 